### PR TITLE
Verify tiny tapeout submission requirements

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -13,8 +13,9 @@ project:
   # Top module name - must start with "tt_um_"
   top_module:  "tt_um_silicon_art"
 
-  # Source files (empty for custom GDS)
-  source_files: []
+  # Source files
+  source_files:
+    - project.v
 
 # Pinout (minimal - art project doesn't need complex I/O)
 pinout:


### PR DESCRIPTION
Add `project.v` to `source_files` in `info.yaml` to fix the failing docs workflow.

The `tt_tool.py --check-docs` action requires at least one source file to be specified, even for custom GDS projects where the GDS is not synthesized from Verilog. Previously, `source_files` was empty, causing the workflow to error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b5b1330-dbe8-4000-b002-002f5b182d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b5b1330-dbe8-4000-b002-002f5b182d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

