### PR TITLE
Debug tiny die area mismatch error

### DIFF
--- a/src/create_silicon_art.py
+++ b/src/create_silicon_art.py
@@ -29,9 +29,9 @@ except ImportError:
 # TinyTapeout 1x1 Tile Specifications
 # =============================================================================
 
-# Die dimensions in micrometers
-DIE_WIDTH_UM = 161.0
-DIE_HEIGHT_UM = 111.52
+# Die dimensions in micrometers (TinyTapeout 1x1 tile)
+DIE_WIDTH_UM = 202.08
+DIE_HEIGHT_UM = 154.98
 
 # Pin layer (met4)
 PIN_LAYER = 71
@@ -115,7 +115,7 @@ PINS = [
 ]
 
 # Pin Y position (at top edge) and dimensions
-PIN_Y = 111.02  # um from bottom
+PIN_Y = 154.48  # um from bottom (0.5 um from top edge)
 PIN_WIDTH = 0.3  # um
 PIN_HEIGHT = 1.0  # um
 

--- a/src/text_to_gds.py
+++ b/src/text_to_gds.py
@@ -45,9 +45,9 @@ SKY130_LAYERS = {
 }
 
 # TinyTapeout tile dimensions in micrometers
-# 1x1 tile: 161.0 x 111.52 um (internal usable area slightly smaller)
-TILE_WIDTH_UM = 161.0
-TILE_HEIGHT_UM = 111.52
+# 1x1 tile: 202.08 x 154.98 um (internal usable area slightly smaller)
+TILE_WIDTH_UM = 202.08
+TILE_HEIGHT_UM = 154.98
 
 # Margins from edge (to avoid DRC issues and overlap with standard cells)
 MARGIN_UM = 10.0


### PR DESCRIPTION
Update TinyTapeout 1x1 tile dimensions to fix die area mismatch error.

The previous die dimensions (161.0 x 111.52 µm) were incorrect for a TinyTapeout 1x1 tile, leading to a "Die area mismatch" error during submission. This PR updates the dimensions to the correct values (202.08 x 154.98 µm) in `src/create_silicon_art.py` and `src/text_to_gds.py`, and adjusts the pin Y position accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-84a9332c-3f1f-49a1-92e7-b3b3fe28dba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84a9332c-3f1f-49a1-92e7-b3b3fe28dba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

