### PR TITLE
Fix tiny tapeout requirements for art piece

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -13,7 +13,7 @@ The design includes:
 4. Power pins (VPWR, VGND) for proper power grid connection
 5. A minimal Verilog stub that passes inputs through with an XOR pattern
 
-The text is centered in the 202.08 × 154.98 µm tile area (TinyTapeout 1x1 tile).
+The text is centered in the 161.0 × 111.52 µm tile area (TinyTapeout TT10 1x1 tile).
 
 ## How to test
 

--- a/info.yaml
+++ b/info.yaml
@@ -1,9 +1,9 @@
 # Tiny Tapeout Silicon Art Project
 project:
-  title:        "Silicon Art - Hello World"
-  author:       "Your Name"
+  title:        "Silicon Art - AWS Canary Token"
+  author:       "Claude"
   discord:      ""
-  description:  "Text art on silicon - HELLO WORLD visible under microscope"
+  description:  "AWS canary token credentials as art on silicon - visible under microscope"
   language:     "Custom GDS"
   clock_hz:     0       # Not a clocked design
 


### PR DESCRIPTION
Update silicon art design to meet TinyTapeout TT10 specifications, resolving pin definition errors and correcting die dimensions.

The previous design used incorrect die dimensions and pin layer/positioning, which caused the "Invalid LEF file: Pin clk is missing layer Metal4" error and other validation failures. This PR aligns the GDS and LEF generation with the exact TT10 1x1 tile specifications (161.0 x 111.52 µm), including precise signal and power pin coordinates and layers, to ensure successful tapeout.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe07116a-a0d9-4cbc-824a-46d4a2c5ca3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe07116a-a0d9-4cbc-824a-46d4a2c5ca3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

